### PR TITLE
fix cmake package for MSVC

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -41,7 +41,7 @@ set(PPLCOMMON_HOLD_DEPS ${PPLCV_HOLD_DEPS})
 
 hpcc_declare_git_dep(pplcommon
     https://github.com/openppl-public/ppl.common.git
-    b4170a465164977f19cd53bae8f00d9a6edbd804)
+    11e885dbc257cacda3cc6b167aab75070360a66b)
 
 # --------------------------------------------------------------------------- #
 

--- a/cmake/pplcv-config.cmake.in
+++ b/cmake/pplcv-config.cmake.in
@@ -43,9 +43,9 @@ set_target_properties(pplcv_static PROPERTIES
 
 if(MSVC)
     set_target_properties(pplcv_static PROPERTIES
-        IMPORTED_LOCATION "${__PPLCV_PACKAGE_ROOTDIR__}/lib/libpplcv_static.lib"
-        IMPORTED_LOCATION_DEBUG "${__PPLCV_PACKAGE_ROOTDIR__}/lib/libpplcv_static.lib"
-        IMPORTED_LOCATION_RELEASE "${__PPLCV_PACKAGE_ROOTDIR__}/lib/libpplcv_static.lib")
+        IMPORTED_LOCATION "${__PPLCV_PACKAGE_ROOTDIR__}/lib/pplcv_static.lib"
+        IMPORTED_LOCATION_DEBUG "${__PPLCV_PACKAGE_ROOTDIR__}/lib/pplcv_static.lib"
+        IMPORTED_LOCATION_RELEASE "${__PPLCV_PACKAGE_ROOTDIR__}/lib/pplcv_static.lib")
 else()
     set_target_properties(pplcv_static PROPERTIES
         IMPORTED_LOCATION "${__PPLCV_PACKAGE_ROOTDIR__}/lib/libpplcv_static.a"


### PR DESCRIPTION
On MSVC there is no "lib" prefix for libraries.

This depends on openppl-public/ppl.common#24

We need to bump ppl.common version in cmake after that PR is merged.