### PR TITLE
Fix msvc cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,16 @@ set(PPLCV_COMPILE_DEFINITIONS )
 
 # --------------------------------------------------------------------------- #
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+    # suppress 'CMAKE_CUDA_ARCHITECTURES' warning
+    cmake_policy(SET CMP0104 OLD)
+endif()
+
 if(HPCC_USE_X86_64)
     include(cmake/x86.cmake)
 endif()
 
 if(HPCC_USE_CUDA)
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-        cmake_policy(SET CMP0104 OLD)
-    endif()
     include(cmake/cuda.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ if(HPCC_USE_X86_64)
 endif()
 
 if(HPCC_USE_CUDA)
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+        cmake_policy(SET CMP0104 OLD)
+    endif()
     include(cmake/cuda.cmake)
 endif()
 

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 md pplcv-build
 cd pplcv-build
 cmake %* -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install ..
-cmake --build . -j --config Release
-cmake --build . --target install -j --config Release
+cmake --build . --config Release
+cmake --install . --config Release
 cd ..

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 md pplcv-build
 cd pplcv-build
 cmake %* -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install ..
-cmake --build . --config Release
+cmake --build . --config Release -- /m
 cmake --install . --config Release
 cd ..

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -13,6 +13,12 @@ if(CUDA_VERSION_MAJOR VERSION_GREATER_EQUAL "10")
     set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_72,code=sm_72")
     set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_75,code=sm_75")
 endif()
+if (CUDA_VERSION_MAJOR VERSION_GREATER_EQUAL "11")
+    set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_80,code=sm_80")
+    if (CUDA_VERSION_MINOR VERSION_GREATER_EQUAL "1")
+        set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_86,code=sm_86")
+    endif ()
+endif ()
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${_NVCC_FLAGS}")
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
For some cmake version like the one that comes with vs2019, I found `cmake --build . -j --config Release` would build Debug version. And move the -j to the end would build the expected Release version. For consistency, I pass the /m to MSBuild tool directly