### PR TITLE
Avoid unnecessary stream synchronization and fix stream of type cudaStreamNonBlocking 

### DIFF
--- a/src/ppl/cv/cuda/crop.cu
+++ b/src/ppl/cv/cuda/crop.cu
@@ -110,7 +110,6 @@ RetCode crop(const uchar* src, int src_rows, int src_cols, int channels,
     code = cudaMemcpy2DAsync(dst, dst_stride, src_start, src_stride,
                         dst_cols * channels * sizeof(uchar), dst_rows,
                         cudaMemcpyDeviceToDevice, stream);
-    cudaStreamSynchronize(stream);
     if (code != cudaSuccess) {
       LOG(ERROR) << "CUDA error: " << cudaGetErrorString(code);
       return RC_DEVICE_MEMORY_ERROR;
@@ -158,7 +157,6 @@ RetCode crop(const float* src, int src_rows, int src_cols, int channels,
     code = cudaMemcpy2DAsync(dst, dst_stride, src_start, src_stride,
                         dst_cols * channels * sizeof(float), dst_rows,
                         cudaMemcpyDeviceToDevice, stream);
-    cudaStreamSynchronize(stream);
     if (code != cudaSuccess) {
       LOG(ERROR) << "CUDA error: " << cudaGetErrorString(code);
       return RC_DEVICE_MEMORY_ERROR;

--- a/src/ppl/cv/cuda/crop.cu
+++ b/src/ppl/cv/cuda/crop.cu
@@ -107,9 +107,10 @@ RetCode crop(const uchar* src, int src_rows, int src_cols, int channels,
   if (scale == 1.f) {
     uchar* src_start = (uchar*)src + top * src_stride +
                        left * channels * sizeof(uchar);
-    code = cudaMemcpy2D(dst, dst_stride, src_start, src_stride,
+    code = cudaMemcpy2DAsync(dst, dst_stride, src_start, src_stride,
                         dst_cols * channels * sizeof(uchar), dst_rows,
-                        cudaMemcpyDeviceToDevice);
+                        cudaMemcpyDeviceToDevice, stream);
+    cudaStreamSynchronize(stream);
     if (code != cudaSuccess) {
       LOG(ERROR) << "CUDA error: " << cudaGetErrorString(code);
       return RC_DEVICE_MEMORY_ERROR;
@@ -154,9 +155,10 @@ RetCode crop(const float* src, int src_rows, int src_cols, int channels,
   if (scale == 1.f) {
     float* src_start = (float*)((uchar*)src + top * src_stride +
                        left * channels * sizeof(float));
-    code = cudaMemcpy2D(dst, dst_stride, src_start, src_stride,
+    code = cudaMemcpy2DAsync(dst, dst_stride, src_start, src_stride,
                         dst_cols * channels * sizeof(float), dst_rows,
-                        cudaMemcpyDeviceToDevice);
+                        cudaMemcpyDeviceToDevice, stream);
+    cudaStreamSynchronize(stream);
     if (code != cudaSuccess) {
       LOG(ERROR) << "CUDA error: " << cudaGetErrorString(code);
       return RC_DEVICE_MEMORY_ERROR;


### PR DESCRIPTION
Use cudaMemcpy2DAsync to avoid unnecessary stream synchronization, and to make stream created by cudaStreamNonBlocking  to work. A cudaStreamSynchronize(stream) should be added before cudaMemcpy2D if stream is type of cudaStreamNonBlocking.


Note that cudaMemcpy includes a synchronization on the default stream. It does not include the equivalent of cudaDeviceSynchronize(). Normally, a synchronization on the default stream synchronizes all other created streams on that device. However, if you create a stream with the cudaStreamNonBlocking flag, that stream will not be synchronized by a synchronization in the default stream.

see [here](https://forums.developer.nvidia.com/t/is-cudamemcpyasync-cudastreamsynchronize-on-default-stream-equal-to-cudamemcpy-non-async/108853/4)



