### PR TITLE
Optimize aarch64 rotate

### DIFF
--- a/src/ppl/cv/arm/dilate.cpp
+++ b/src/ppl/cv/arm/dilate.cpp
@@ -24,6 +24,7 @@
 #include <arm_neon.h>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <float.h>
 
 namespace ppl {

--- a/src/ppl/cv/arm/erode.cpp
+++ b/src/ppl/cv/arm/erode.cpp
@@ -24,6 +24,7 @@
 #include <arm_neon.h>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <float.h>
 
 namespace ppl { 

--- a/src/ppl/cv/arm/intrinutils_neon.hpp
+++ b/src/ppl/cv/arm/intrinutils_neon.hpp
@@ -155,20 +155,26 @@ static inline uint32x4_t neon_reverse_u32x4(uint32x4_t va)
 
 static inline void neon_rotate90_f32_4x4(float32x4_t &va, float32x4_t &vb, float32x4_t &vc, float32x4_t &vd)
 {
-    neon_transpose_f32_4x4(va, vb, vc, vd);
-    va = neon_reverse_f32x4(va);
-    vb = neon_reverse_f32x4(vb);
-    vc = neon_reverse_f32x4(vc);
-    vd = neon_reverse_f32x4(vd);
+    float32x4_t v20_0 = vzip1q_f32(vc, va);
+    float32x4_t v31_0 = vzip1q_f32(vd, vb);
+    float32x4_t v20_2 = vzip2q_f32(vc, va);
+    float32x4_t v31_2 = vzip2q_f32(vd, vb);
+    va = vzip1q_f32(v31_0, v20_0);
+    vb = vzip2q_f32(v31_0, v20_0);
+    vc = vzip1q_f32(v31_2, v20_2);
+    vd = vzip2q_f32(v31_2, v20_2);
 }
 
 static inline void neon_rotate90_u32_4x4(uint32x4_t &va, uint32x4_t &vb, uint32x4_t &vc, uint32x4_t &vd)
 {
-    neon_transpose_u32_4x4(va, vb, vc, vd);
-    va = neon_reverse_u32x4(va);
-    vb = neon_reverse_u32x4(vb);
-    vc = neon_reverse_u32x4(vc);
-    vd = neon_reverse_u32x4(vd);
+    uint32x4_t v20_0 = vzip1q_u32(vc, va);
+    uint32x4_t v31_0 = vzip1q_u32(vd, vb);
+    uint32x4_t v20_2 = vzip2q_u32(vc, va);
+    uint32x4_t v31_2 = vzip2q_u32(vd, vb);
+    va = vzip1q_u32(v31_0, v20_0);
+    vb = vzip2q_u32(v31_0, v20_0);
+    vc = vzip1q_u32(v31_2, v20_2);
+    vd = vzip2q_u32(v31_2, v20_2);
 }
 
 static inline void neon_rotate270_f32_4x4(float32x4_t &va, float32x4_t &vb, float32x4_t &vc, float32x4_t &vd)
@@ -194,15 +200,32 @@ static inline void neon_rotate90_u8_8x8(uint8x8_t &va,
                                         uint8x8_t &vg,
                                         uint8x8_t &vh)
 {
-    neon_transpose_u8_8x8(va, vb, vc, vd, ve, vf, vg, vh);
-    va = neon_reverse_u8x8(va);
-    vb = neon_reverse_u8x8(vb);
-    vc = neon_reverse_u8x8(vc);
-    vd = neon_reverse_u8x8(vd);
-    ve = neon_reverse_u8x8(ve);
-    vf = neon_reverse_u8x8(vf);
-    vg = neon_reverse_u8x8(vg);
-    vh = neon_reverse_u8x8(vh);
+    uint8x8_t v40_0 = vzip1_u8(ve, va);
+    uint8x8_t v51_0 = vzip1_u8(vf, vb);
+    uint8x8_t v62_0 = vzip1_u8(vg, vc);
+    uint8x8_t v73_0 = vzip1_u8(vh, vd);
+    uint8x8_t v40_4 = vzip2_u8(ve, va);
+    uint8x8_t v51_4 = vzip2_u8(vf, vb);
+    uint8x8_t v62_4 = vzip2_u8(vg, vc);
+    uint8x8_t v73_4 = vzip2_u8(vh, vd);
+
+    uint8x8_t v6420_0 = vzip1_u8(v62_0, v40_0);
+    uint8x8_t v7531_0 = vzip1_u8(v73_0, v51_0);
+    uint8x8_t v6420_2 = vzip2_u8(v62_0, v40_0);
+    uint8x8_t v7531_2 = vzip2_u8(v73_0, v51_0);
+    uint8x8_t v6420_4 = vzip1_u8(v62_4, v40_4);
+    uint8x8_t v7531_4 = vzip1_u8(v73_4, v51_4);
+    uint8x8_t v6420_6 = vzip2_u8(v62_4, v40_4);
+    uint8x8_t v7531_6 = vzip2_u8(v73_4, v51_4);
+
+    va = vzip1_u8(v7531_0, v6420_0);
+    vb = vzip2_u8(v7531_0, v6420_0);
+    vc = vzip1_u8(v7531_2, v6420_2);
+    vd = vzip2_u8(v7531_2, v6420_2);
+    ve = vzip1_u8(v7531_4, v6420_4);
+    vf = vzip2_u8(v7531_4, v6420_4);
+    vg = vzip1_u8(v7531_6, v6420_6);
+    vh = vzip2_u8(v7531_6, v6420_6);
 }
 
 static inline void neon_rotate270_u8_8x8(uint8x8_t &va,


### PR DESCRIPTION
Reduce NEON sequence.

On Kyro260 (Cortex-A53)

Before

```
BM_Rotate_ppl_aarch64<float, c3, 90>/640/480/iterations:10/manual_time           4917958 ns    236724000 ns           10 items_per_second=203.336/s
BM_Rotate_ppl_aarch64<float, c3, 90>/1920/1080/iterations:10/manual_time        32919244 ns   1581717344 ns           10 items_per_second=30.3774/s
BM_Rotate_ppl_aarch64<uint8_t, c3, 90>/640/480/iterations:10/manual_time         2124198 ns    101570155 ns           10 items_per_second=470.766/s
BM_Rotate_ppl_aarch64<uint8_t, c3, 90>/1920/1080/iterations:10/manual_time      13242732 ns    638636764 ns           10 items_per_second=75.5131/s
```

After

```
BM_Rotate_ppl_aarch64<float, c3, 90>/640/480/iterations:10/manual_time           4576840 ns    218713006 ns           10 items_per_second=218.491/s
BM_Rotate_ppl_aarch64<float, c3, 90>/1920/1080/iterations:10/manual_time        27311788 ns   1319167490 ns           10 items_per_second=36.6142/s
BM_Rotate_ppl_aarch64<uint8_t, c3, 90>/640/480/iterations:10/manual_time         2052890 ns     98462090 ns           10 items_per_second=487.118/s
BM_Rotate_ppl_aarch64<uint8_t, c3, 90>/1920/1080/iterations:10/manual_time      13082652 ns    629270526 ns           10 items_per_second=76.4371/s
```